### PR TITLE
Made writing java code "snippets" easier.

### DIFF
--- a/src/codeswap.py
+++ b/src/codeswap.py
@@ -1,0 +1,51 @@
+import re
+
+
+def swap(language, source):
+    if language == 'java':
+        return for_java(source)
+    else:
+        return source
+
+
+def for_java(inp):
+    out = ''
+
+    if re.match('(\n|.)*(public class)(.|\n)*', inp):
+        return inp
+
+    lines = inp.split('\n')
+    for line in lines:
+        if line.lstrip().startswith('import'):
+            out += line + '\n'
+
+    out += 'public class temp extends Object'
+
+    # for line in lines:
+    #     if line.lstrip().startswith('extends'):
+    #         line = line.replace(';', '')
+    #         out += ', ' + line[line.index('extends ') + 8:]
+    #         break
+
+    out += ''' {
+    public static void main(String[] args) {'''
+
+    if 'extends' in inp:
+        yup = False
+        for line in lines:
+            if 'extends' in line:
+                yup = True
+            elif yup:
+                out += '        ' + line + '\n'
+    elif 'import' in inp:
+        for line in lines:
+            if not line.startswith('import'):
+                out += '        ' + line + '\n'
+    else:
+        for line in lines:
+            out += '        ' + line + '\n'
+
+    out += '    }\n}'
+
+    return out
+

--- a/src/cogs/run.py
+++ b/src/cogs/run.py
@@ -11,6 +11,7 @@ import json
 from discord import Embed
 from discord.ext import commands
 from discord.utils import escape_mentions
+import codeswap
 
 
 class Run(commands.Cog, name='CodeExecution'):
@@ -79,6 +80,7 @@ class Run(commands.Cog, name='CodeExecution'):
             source = message[1].lstrip(language).strip()
         else:
             source = message[1].strip()
+        source = codeswap.swap(language, source)
         language = self.languages[language]
         data = {'language': language, 'source': source, 'args': args}
 


### PR DESCRIPTION
Code pieces which only requires a import block and the main method can now be written in this format:

<import statements>
<main method block>

Example:
/run java
1
2
3
```java
import java.util.List;
List.of(args).forEach(System.out::println);
```

Will be interpreted as:
import java.util.List;
public class temp {
    public static void main(String[] args) {
        List.of(args).forEach(System.out::println);
    }
}