### PR TITLE
Add message for no output

### DIFF
--- a/src/cogs/run.py
+++ b/src/cogs/run.py
@@ -156,8 +156,8 @@ class Run(commands.Cog, name='CodeExecution'):
                 + output
                 + '```'
             )
-        else:
-            return f'Your code ran without output {ctx.author.mention}'
+        
+        return f'Your code ran without output {ctx.author.mention}'
 
     @commands.command()
     async def run(self, ctx, *, source=None):

--- a/src/cogs/run.py
+++ b/src/cogs/run.py
@@ -149,12 +149,15 @@ class Run(commands.Cog, name='CodeExecution'):
                     ctx
                 )
 
-        return (
-            f'Here is your output {ctx.author.mention}\n'
-            + f'```{syntax or ""}\n'
-            + output
-            + '```'
-        )
+        if len(output) > 0:
+            return (
+                f'Here is your output {ctx.author.mention}\n'
+                + f'```{syntax or ""}\n'
+                + output
+                + '```'
+            )
+        else:
+            return f'Your code ran without output {ctx.author.mention}'
 
     @commands.command()
     async def run(self, ctx, *, source=None):


### PR DESCRIPTION
This fixes the bug where it outputs the syntax name when there's no output