### PR TITLE
Add new boilerplate for C/C++ and go

### DIFF
--- a/src/cogs/utils/codeswap.py
+++ b/src/cogs/utils/codeswap.py
@@ -5,8 +5,28 @@ def add_boilerplate(language, source):
         return for_rust(source)
     elif language == 'c' or language == 'cpp':
         return for_c_cpp(source)
+    elif language == 'go':
+        return for_go(source)
     else:
         return source
+
+def for_go(source):
+    if 'main' in source:
+        return source
+
+    package = ['package main']
+    imports = []
+    code = ['func main() {']
+
+    lines = source.split('\n')
+    for line in lines:
+        if line.lstrip().startswith('import'):
+            imports.append(line)
+        else:
+            code.append(line)
+
+    code.append('}')
+    return '\n'.join(package + imports + code)
 
 def for_c_cpp(source):
     if 'main' in source:
@@ -25,6 +45,7 @@ def for_c_cpp(source):
 
     code.append('}')
     return '\n'.join(imports + code)
+
 
 def for_java(source):
     if 'public class' in source:

--- a/src/cogs/utils/codeswap.py
+++ b/src/cogs/utils/codeswap.py
@@ -3,9 +3,28 @@ def add_boilerplate(language, source):
         return for_java(source)
     elif language == 'rust':
         return for_rust(source)
+    elif language == 'c' or language == 'cpp':
+        return for_c_cpp(source)
     else:
         return source
 
+def for_c_cpp(source):
+    if 'main' in source:
+        return source
+
+    imports = []
+    code = ['int main() {']
+
+    lines = source.replace(';', ';\n').split('\n')
+    for line in lines:
+        print(line)
+        if line.lstrip().startswith('include'):
+            imports.append(line)
+        else:
+            code.append(line)
+
+    code.append('}')
+    return '\n'.join(imports + code)
 
 def for_java(source):
     if 'public class' in source:

--- a/src/cogs/utils/codeswap.py
+++ b/src/cogs/utils/codeswap.py
@@ -1,14 +1,13 @@
 def add_boilerplate(language, source):
     if language == 'java':
         return for_java(source)
-    elif language == 'rust':
+    if language == 'rust':
         return for_rust(source)
-    elif language == 'c' or language == 'cpp':
+    if language == 'c' or language == 'cpp':
         return for_c_cpp(source)
-    elif language == 'go':
+    if language == 'go':
         return for_go(source)
-    else:
-        return source
+    return source
 
 def for_go(source):
     if 'main' in source:


### PR DESCRIPTION
I kept C and C++ in the same function for now. If we ever want to add automatic imports such as stdio.h in C or iostream in C++,
 we will have to separate them. As it stands it works fine, however.