### PR TITLE
 Disable code block escaping

### DIFF
--- a/src/cogs/run.py
+++ b/src/cogs/run.py
@@ -136,6 +136,10 @@ class Run(commands.Cog, name='CodeExecution'):
         len_syntax = 0 if syntax is None else len(syntax)
 
         output = escape_mentions('\n'.join(r['output'].split('\n')[:30]))
+
+        # Disable code block escaping
+        output = output.replace("```", "'''")
+
         if len(output) > 1945-len_syntax:
             output = output[:1945-len_syntax] + '[...]'
 


### PR DESCRIPTION
 Disable code block escaping by replacing all ` with ' to make the output more unified.