### PR TITLE
Fix c cpp includes codeswap

### DIFF
--- a/src/cogs/utils/codeswap.py
+++ b/src/cogs/utils/codeswap.py
@@ -36,7 +36,7 @@ def for_c_cpp(source):
 
     lines = source.replace(';', ';\n').split('\n')
     for line in lines:
-        if line.lstrip().startswith('include'):
+        if line.lstrip().startswith('#include'):
             imports.append(line)
         else:
             code.append(line)


### PR DESCRIPTION
Fixes the codeswap function for c/cpp. Previously would place any `#includes` inside the `int main()` boilerplate. For example input (cpp):
`#include <iostream>
std::cout<<"test"<<std::endl;`
Previous output with added boilerplate would be: 
`int main() {
#include <iostream>
std::cout<<"test"<<std::endl;
}`
Whereas now it outputs:
`#include <iostream>
int main() {
std::cout<<"test"<<std:endl;
}`