### PR TITLE
Added C# boilerplate & resolve language alias before passing to codeswap

### DIFF
--- a/src/cogs/run.py
+++ b/src/cogs/run.py
@@ -96,11 +96,13 @@ class Run(commands.Cog, name='CodeExecution'):
         if not source:
             raise commands.BadArgument(f'No source code found')
 
+        # Resolve aliases for language
+        language = self.languages[language]
+
         # Add boilerplate code to supported languages
         source = add_boilerplate(language, source)
 
         # Call piston API
-        language = self.languages[language]
         data = {'language': language, 'source': source, 'args': args, 'stdin': stdin or ""}
         headers = {'Authorization': self.client.config["emkc_key"]}
 

--- a/src/cogs/utils/codeswap.py
+++ b/src/cogs/utils/codeswap.py
@@ -7,6 +7,8 @@ def add_boilerplate(language, source):
         return for_c_cpp(source)
     if language == 'go':
         return for_go(source)
+    if language == 'csharp':
+        return for_csharp(source)
     return source
 
 def for_go(source):
@@ -44,6 +46,21 @@ def for_c_cpp(source):
     code.append('}')
     return '\n'.join(imports + code)
 
+def for_csharp(source):
+    if 'static void Main' in source:
+        return source
+
+    imports=[]
+    code = ['class Program{static void Main(string[] args){']
+
+    lines = source.replace(';', ';\n').split('\n')
+    for line in lines:
+        if line.lstrip().startswith('using'):
+            imports.append(line)
+        else:
+            code.append(line)
+    code.append('}}')
+    return '\n'.join(imports + code)
 
 def for_java(source):
     if 'public class' in source:


### PR DESCRIPTION
Added C# boilerplate to the codeswap. For example, input of:
````csharp
using System;
Console.WriteLine("Hello World");
````
Would be evaluated as : 
````csharp
using System;
class Program{
    static void Main(string[] args){
        Console.WriteLine("Hello World");
    }
}
````
Additionally, before passing the source to the codeswap/boilerplate function, any language alias is resolved to the 'actual name' of the language. This allows for variants such as c#, cs to be executed as csharp in the boilerplate. Similarly, this applies to any language that can have added boilerplate, but also have aliases, for example cpp, c++, cc etc.