### PR TITLE
Added PHP boilerplate

### DIFF
--- a/src/cogs/utils/codeswap.py
+++ b/src/cogs/utils/codeswap.py
@@ -9,6 +9,8 @@ def add_boilerplate(language, source):
         return for_go(source)
     if language == 'csharp':
         return for_csharp(source)
+    if language == 'php':
+        return for_php(source)
     return source
 
 def for_go(source):
@@ -80,6 +82,11 @@ def for_java(source):
     code.append('}}')
     return '\n'.join(imports + code)
 
+def for_php(source):
+    if source.startswith('<?'):
+        return source
+        
+    return '<?' + source
 
 def for_rust(source):
     if 'fn main' in source:


### PR DESCRIPTION
Added PHP boilerplate to codeswap.
Example:
`echo "Hello";`
Would be evaluated as:
`<?echo "Hello";`
This does rely on `short_open_tag` being enabled on piston, however from my testing this appears to be true.