### PR TITLE
Fixed bug with non-public class

### DIFF
--- a/src/cogs/utils/codeswap.py
+++ b/src/cogs/utils/codeswap.py
@@ -65,7 +65,7 @@ def for_csharp(source):
     return '\n'.join(imports + code)
 
 def for_java(source):
-    if 'public class' in source:
+    if 'class' in source:
         return source
 
     imports = []


### PR DESCRIPTION
```
class Main{
  public static void main(String[] args) throws Exception{
    System.out.println("works now");
  }
}
```
Used to get wrapped into the template causing an error