### PR TITLE
Update codeswap.py

### DIFF
--- a/src/cogs/utils/codeswap.py
+++ b/src/cogs/utils/codeswap.py
@@ -5,7 +5,7 @@ def add_boilerplate(language, source):
         return for_scala(source)
     if language == 'rust':
         return for_rust(source)
-    if language == 'c' or language == 'cpp':
+    if language == 'c' or language == 'c++':
         return for_c_cpp(source)
     if language == 'go':
         return for_go(source)


### PR DESCRIPTION
`self.languages` in run.py maps c++, cpp and g++ to c++ as per the runtime list (https://emkc.org/api/v2/piston/runtimes), as a result all the `add_boilerplate` calls with a c++ alias get called with `language == 'c++'` and no boilerplate gets added.