### PR TITLE
Fixed issue with languages that are only "aliases" for another runtime version

### DIFF
--- a/src/cogs/run.py
+++ b/src/cogs/run.py
@@ -55,6 +55,7 @@ class Run(commands.Cog, name='CodeExecution'):
             self.versions[language] = runtime['version']
             for alias in runtime['aliases']:
                 self.languages[alias] = language
+                self.versions[alias] = runtime['version']
 
     async def send_to_log(self, ctx, language, source):
         logging_data = {
@@ -158,7 +159,7 @@ class Run(commands.Cog, name='CodeExecution'):
         # Resolve aliases for language
         language = self.languages[alias]
 
-        version = self.versions[language]
+        version = self.versions[alias]
 
         # Add boilerplate code to supported languages
         source = add_boilerplate(language, source)


### PR DESCRIPTION
@brtwrst 
> there is a problem with languages that are only "aliases" for another runtime. Example Deno:
> ![image](https://user-images.githubusercontent.com/50732964/129475528-847c5224-7bc1-4348-959a-fcd69aff988c.png)
> the version dict also has to include the version for each alias and use that to call the api.

This pull request should fix it by storing version for each alias