### PR TITLE
Add note about location of tilde key in /run help

### DIFF
--- a/src/cogs/run.py
+++ b/src/cogs/run.py
@@ -366,6 +366,7 @@ class Run(commands.Cog, name='CodeExecution'):
             '\n\n**You can run code like this:**\n'
             '/run <language>\ncommand line parameters (optional) - 1 per line\n'
             '\\`\\`\\`\nyour code\n\\`\\`\\`\nstandard input (optional)\n'
+            '\n**Note: the \\` character is usually directly below ESC**\n'
             '\n**Provided by the Engineer Man Discord Server - visit:**\n'
             '• https://emkc.org/run to get it in your own server\n'
             '• https://discord.gg/engineerman for more info\n'


### PR DESCRIPTION
I've seen a lot of people confused about the character used for code blocks in Discord, so adding a note to /run should make it easier to use. 