### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root=true
+
+[*]
+charset=utf-8
+end_of_line=lf
+indent_style=space
+indent_size=4
+insert_final_newline=true
+trim_trailing_whitespace=true


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org/) is understood by most popular IDE's and text editors (either natively or via plugin/extension), and is useful for configuring editors to apply certain coding styles to files.

I thought this would be useful based on [this section](https://github.com/engineer-man/piston-bot#code-styling--ide-settings) in the README.